### PR TITLE
Remove quoted paths in generator expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,15 @@ target_include_directories(NotEnoughStandards INTERFACE
 )
 
 target_sources(NotEnoughStandards INTERFACE
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/shared_library.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/shared_memory.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/named_mutex.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/semaphore.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/named_semaphore.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/pipe.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/process.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/hash.hpp">
-    $<BUILD_INTERFACE:"${PROJECT_SOURCE_DIR}/include/nes/thread_pool.hpp">
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/shared_library.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/shared_memory.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/named_mutex.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/semaphore.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/named_semaphore.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/pipe.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/process.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/hash.hpp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/nes/thread_pool.hpp>
     )
 
 if(UNIX)


### PR DESCRIPTION
Fixes Alairion/not-enough-standards#4.

I have built this in cases when `${PROJECT_SOURCE_DIR}` contained a space, and the lack of quotes wasn't a problem.